### PR TITLE
feat(rest): add Spring Boot REST module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,16 @@
 name: Build
-
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  pull_request: { branches: [ main ] }
+  push: { branches: [ main, feat/** ] }
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          distribution: 'microsoft'
-          java-version: '21'
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - name: Build with Gradle
-        run: ./gradlew clean build
+          distribution: temurin
+          java-version: 21
+      - run: chmod +x gradlew
+      - run: ./gradlew clean build --stacktrace

--- a/README.md
+++ b/README.md
@@ -1,32 +1,30 @@
-# File-Type-Analyzer
+# File-Type-Analyzer (Monorepo)
 
-Educational project to detect file types based on signatures.
+Multi-project: common logic in `core`, two applications: `app-cli` (CLI) and `app-rest` (REST).
 
-## Structure
-- `core`
-    - `model/PatternDBRecord.java` — signature definition
-    - `service/SignatureDetector.java` — file type detection
-- `app-cli` — console application (analyzes a single file or a whole folder)
-- `app-rest` — REST API (under development)
+## Modules
+- `core` — loads `patterns.db`, signature detection logic (`SignatureDetector`).
+- `app-cli` — command-line tool for local file analysis.
+- `app-rest` — Spring Boot REST API for batch file analysis.
 
-## Features
-- Reads the first 560 bytes of a file (constant in CLI).
-- `patterns.db` with signatures stored in `core/resources`.
-- CLI accepts both file and directory path:
-  ```bash
-  # analyze single file
-  gradlew :app-cli:run --args="test_files/sample.pdf"
+## Quick start
+```bash
+# CLI
+./gradlew :app-cli:run --args="path/to/files"
+# REST
+./gradlew :app-rest:bootRun
+```
 
-  # analyze folder
-  gradlew :app-cli:run --args="test_files"
-  ```
+## Tests
+```bash
+./gradlew test
+# or per module
+./gradlew :app-rest:test
+```
 
-## Roadmap
-- Move parameters into `application.properties` (for REST).
-- Extend signatures database.
-- Add flexible output formats (CSV/JSON).
+## Branches
+- `main` — stable version (CLI).
+- `feature/rest-api` — REST development, merged into `main` after review.
 
-## Tech stack
-- Java 24
-- Gradle 8
-- Spring Boot 3.5 (for REST module)
+## Requirements
+Java 21/24, Gradle 8.x.

--- a/app-cli/README.md
+++ b/app-cli/README.md
@@ -1,0 +1,17 @@
+# App-CLI
+
+CLI version of File-Type-Analyzer — quick file type detection from the console.
+
+## Run
+```bash
+./gradlew :app-cli:run --args="path/to/files"
+```
+
+## Example
+```bash
+./gradlew :app-cli:run --args="test_files"
+```
+Output: one line per file, format `filename: TYPE`.
+
+## Notes
+- Uses `core` and `patterns.db` from the classpath.

--- a/app-rest/README.md
+++ b/app-rest/README.md
@@ -1,0 +1,31 @@
+# App-REST
+
+Spring Boot REST API for file type detection. Supports multiple file uploads.
+
+## Run
+```bash
+./gradlew :app-rest:bootRun
+# optional properties:
+./gradlew :app-rest:bootRun --args="--server.port=9090 --readLimit=560"
+```
+
+## API
+`POST /api/detect` — `multipart/form-data` with parameter `files` (can be repeated).
+
+```bash
+curl -F "files=@test_files/sample.pdf" -F "files=@test_files/my_jpeg.jpg" http://localhost:8080/api/detect
+```
+Response:
+```json
+{ "sample.pdf": "PDF", "my_jpeg.jpg": "JPEG" }
+```
+
+### Errors
+- `400` `{ "error": "File is empty" }`
+- `500` `{ "error": "Internal error" }`
+
+## Tests
+Integration tests using `MockMvc`:
+```bash
+./gradlew :app-rest:test
+```

--- a/app-rest/build.gradle
+++ b/app-rest/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id "java"
 }
 java { toolchain { languageVersion = JavaLanguageVersion.of(21) } }
+
 dependencies {
     implementation(project(":core"))
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/app-rest/src/main/java/net/psv73/filetype/RestApplication.java
+++ b/app-rest/src/main/java/net/psv73/filetype/RestApplication.java
@@ -2,9 +2,9 @@ package net.psv73.filetype;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
-public class RestApp {
+@SpringBootApplication(scanBasePackages = "net.psv73.filetype")
+public class RestApplication {
     public static void main(String[] args) {
-        SpringApplication.run(RestApp.class, args);
+        SpringApplication.run(RestApplication.class, args);
     }
 }

--- a/app-rest/src/main/java/net/psv73/filetype/api/AnalyzerService.java
+++ b/app-rest/src/main/java/net/psv73/filetype/api/AnalyzerService.java
@@ -1,0 +1,25 @@
+package net.psv73.filetype.api;
+
+import net.psv73.filetype.service.SignatureDetector;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Service
+public class AnalyzerService {
+    private final SignatureDetector detector;
+
+    public AnalyzerService(@Value("classpath:patterns.db") Resource db) throws IOException {
+        // если у тебя есть метод loadFromPath
+        this.detector = new SignatureDetector();
+    }
+
+    public String analyze(byte[] fileBytes) throws IOException {
+        if (fileBytes == null || fileBytes.length == 0)
+            throw new IllegalArgumentException("File is empty");
+        return detector.detect(fileBytes);
+    }
+}
+

--- a/app-rest/src/main/java/net/psv73/filetype/api/DetectController.java
+++ b/app-rest/src/main/java/net/psv73/filetype/api/DetectController.java
@@ -6,21 +6,35 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @RestController
 @RequestMapping("/api")
 public class DetectController {
+
     private final SignatureDetector detector;
-    public DetectController(SignatureDetector detector) { this.detector = detector; }
+    private final AnalyzerService service;
+
+    public DetectController(SignatureDetector detector, AnalyzerService service) {
+        this.detector = detector;
+        this.service = service;
+    }
 
     @PostMapping(value = "/detect", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public Map<String, String> detect(@RequestPart("file") MultipartFile file) throws IOException {
-        String type = detector.detect(file.getBytes());
-        return Map.of(
-                "file", file.getOriginalFilename() == null ? "uploaded" : file.getOriginalFilename(),
-                "size", String.valueOf(file.getSize()),
-                "type", type
-        );
+    public Map<String, String> detect(@RequestPart("files") MultipartFile[] files) throws IOException {
+
+        Map<String,String> result = new LinkedHashMap<>();
+
+        for (MultipartFile f : files) {
+            result.put(f.getOriginalFilename(), service.analyze(f.getBytes()));
+        }
+
+        return result;
+    }
+
+    @GetMapping("/read-limit")
+    public int getLimit() {
+        return detector.getReadLimit();
     }
 }

--- a/app-rest/src/main/java/net/psv73/filetype/api/GlobalExceptionHandler.java
+++ b/app-rest/src/main/java/net/psv73/filetype/api/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package net.psv73.filetype.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    Map<String, Object> badRequest(IllegalArgumentException e) {
+        return Map.of("error", e.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    Map<String, Object> serverError(Exception e) {
+        return Map.of("error", "Internal error");
+    }
+}

--- a/app-rest/src/main/java/net/psv73/filetype/api/HealthController.java
+++ b/app-rest/src/main/java/net/psv73/filetype/api/HealthController.java
@@ -1,0 +1,13 @@
+package net.psv73.filetype.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+    @GetMapping("/api/health")
+    public String health() {
+        return "OK";
+    }
+}

--- a/app-rest/src/main/java/net/psv73/filetype/config/DetectorConfig.java
+++ b/app-rest/src/main/java/net/psv73/filetype/config/DetectorConfig.java
@@ -1,6 +1,7 @@
 package net.psv73.filetype.config;
 
 import net.psv73.filetype.service.SignatureDetector;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -8,8 +9,11 @@ import java.io.IOException;
 
 @Configuration
 public class DetectorConfig {
+
     @Bean
-    public SignatureDetector signatureDetector() throws IOException {
-        return new SignatureDetector();
+    public SignatureDetector signatureDetector(
+            @Value("${detector.read-limit:560}") int readLimit
+    ) throws IOException {
+        return new SignatureDetector(readLimit);
     }
 }

--- a/app-rest/src/main/resources/application.properties
+++ b/app-rest/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+server.port=8080
+detector.read-limit=560
+detector.db-file=patterns.db

--- a/app-rest/src/main/resources/application.yml
+++ b/app-rest/src/main/resources/application.yml
@@ -1,3 +1,0 @@
-server.port: 8080
-spring.servlet.multipart.max-file-size: 10MB
-spring.servlet.multipart.max-request-size: 10MB

--- a/app-rest/src/test/java/net/psv73/filetype/api/DetectControllerTest.java
+++ b/app-rest/src/test/java/net/psv73/filetype/api/DetectControllerTest.java
@@ -1,0 +1,43 @@
+package net.psv73.filetype.api;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class DetectControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void detectsMultipleFiles() throws Exception {
+        var pdf = new MockMultipartFile(
+                "files", "a.pdf", "application/pdf",
+                new byte[]{'%', 'P', 'D', 'F', '-'});
+        var jpg = new MockMultipartFile(
+                "files", "b.jpg", "image/jpeg",
+                new byte[]{(byte)0xFF, (byte)0xD8, (byte)0xFF});
+
+        mvc.perform(multipart("/api/detect").file(pdf).file(jpg))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.['a.pdf']").exists())
+                .andExpect(jsonPath("$.['b.jpg']").exists());
+    }
+
+    @Test
+    void emptyFileReturns400() throws Exception {
+        var empty = new MockMultipartFile("files","x.bin","application/octet-stream", new byte[0]);
+        mvc.perform(multipart("/api/detect").file(empty))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("File is empty"));
+    }
+}

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,18 @@
+# Core
+
+Shared logic for detecting file type based on signatures from `patterns.db`.
+
+## Components
+- `SignatureDetector` — reads `patterns.db` from classpath and detects file type from bytes.
+- Constructors:
+  - `SignatureDetector()`
+  - `SignatureDetector(int readLimit)` — defines the maximum prefix length (bytes) read from a file.
+
+## Resources
+`patterns.db` is located in `core/src/main/resources` and included in the classpath for all modules (CLI, REST).
+
+## Usage
+```java
+var detector = new SignatureDetector();          // or new SignatureDetector(560);
+String type = detector.detect(fileBytes);
+```

--- a/core/src/main/java/net/psv73/filetype/service/SignatureDetector.java
+++ b/core/src/main/java/net/psv73/filetype/service/SignatureDetector.java
@@ -10,11 +10,17 @@ import java.util.*;
 public class SignatureDetector {
 
     private static final String PATTERN_DB = "patterns.db";
-    private static final int DEFAULT_READ_LIMIT = 560;
+    private final int readLimit;
 
     private final List<PatternDBRecord> patterns;
 
     public SignatureDetector() throws IOException {
+        this(560);
+    }
+
+    public SignatureDetector(int readLimit) throws IOException {
+        this.readLimit = readLimit;
+
         try (InputStream is = getClass().getClassLoader().getResourceAsStream(PATTERN_DB)) {
             if (is == null) throw new FileNotFoundException(PATTERN_DB + " not found on classpath");
             try (BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
@@ -23,8 +29,12 @@ public class SignatureDetector {
         }
     }
 
+    public int getReadLimit() {
+        return readLimit;
+    }
+
     public String detect(Path path) throws IOException {
-        byte[] head = readHead(path, DEFAULT_READ_LIMIT);
+        byte[] head = readHead(path, this.readLimit);
         return detect(head);
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
-org.gradle.java.home=C:\\Program Files\\Java\\jdk-21
 org.gradle.jvmargs=--enable-native-access=ALL-UNNAMED
 


### PR DESCRIPTION
This PR introduces the new REST module (app-rest) based on Spring Boot.

- Added /api/detect endpoint with multi-file upload support
- Integrated core SignatureDetector logic
- Implemented validation and global error handling
- Added integration tests using MockMvc
- Added English README files for root, core, CLI, and REST